### PR TITLE
Support fastify v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   instance.addHook("onRequest", (request, reply, next) => {
     // Store the start timer in nanoseconds resolution
     // istanbul ignore next
-    if (request.req) {
+    if (request.req && reply.res) {
       // support fastify >= v2
       request.req[symbolRequestTime] = process.hrtime();
       reply.res[symbolServerTiming] = {};

--- a/index.js
+++ b/index.js
@@ -43,10 +43,10 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   opts.header = opts.header || "X-Response-Time";
 
   // Hook to be triggered on request (start time)
-  instance.addHook("onRequest", (req, res, next) => {
+  instance.addHook("onRequest", (request, reply, next) => {
     // Store the start timer in nanoseconds resolution
-    req[symbolRequestTime] = process.hrtime();
-    res[symbolServerTiming] = {};
+    request.req[symbolRequestTime] = process.hrtime();
+    reply.res[symbolServerTiming] = {};
 
     next();
   });
@@ -90,4 +90,4 @@ module.exports = fastifyPlugin((instance, opts, next) => {
 
   next();
   // Not before 0.31 (onSend hook added to this version)
-}, ">= 0.31");
+}, ">= 2");

--- a/index.js
+++ b/index.js
@@ -45,8 +45,15 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   // Hook to be triggered on request (start time)
   instance.addHook("onRequest", (request, reply, next) => {
     // Store the start timer in nanoseconds resolution
-    request.req[symbolRequestTime] = process.hrtime();
-    reply.res[symbolServerTiming] = {};
+    // istanbul ignore next
+    if (request.req) {
+      // support fastify >= v2
+      request.req[symbolRequestTime] = process.hrtime();
+      reply.res[symbolServerTiming] = {};
+    } else {
+      request[symbolRequestTime] = process.hrtime();
+      reply[symbolServerTiming] = {};
+    }
 
     next();
   });
@@ -90,4 +97,4 @@ module.exports = fastifyPlugin((instance, opts, next) => {
 
   next();
   // Not before 0.31 (onSend hook added to this version)
-}, ">= 2");
+}, ">= 0.31");

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "header"
   ],
   "devDependencies": {
-    "fastify": "^1.13.1",
+    "fastify": "^2.0.0-rc.1",
     "request": "^2.81.0",
     "tap": "^12.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "header"
   ],
   "devDependencies": {
-    "fastify": "^2.0.0-rc.1",
+    "fastify": "^2.0.0-rc.2",
     "request": "^2.81.0",
     "tap": "^12.1.0"
   },


### PR DESCRIPTION
Add support for v2, also supporting v0.31 and above.

I had to pick a fastify version in dev deps and went with v2, but you can still set it to v1 and tests will still pass.

Also added an instanbul comment to skip the v1/v2 test since it will always be one or the other.