### PR TITLE
Force usage of fastify 2.0 minimum and clean code

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,14 +46,8 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   instance.addHook("onRequest", (request, reply, next) => {
     // Store the start timer in nanoseconds resolution
     // istanbul ignore next
-    if (request.req && reply.res) {
-      // support fastify >= v2
-      request.req[symbolRequestTime] = process.hrtime();
-      reply.res[symbolServerTiming] = {};
-    } else {
-      request[symbolRequestTime] = process.hrtime();
-      reply[symbolServerTiming] = {};
-    }
+    request[symbolRequestTime] = process.hrtime();
+    reply[symbolServerTiming] = {};
 
     next();
   });
@@ -62,7 +56,7 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   instance.addHook("onSend", (request, reply, payload, next) => {
 
     // check if Server-Timing need to be added
-    const serverTiming = reply.res[symbolServerTiming];
+    const serverTiming = reply[symbolServerTiming];
     const headers = [];
     for (const name of Object.keys(serverTiming)) {
       headers.push(serverTiming[name]);
@@ -84,7 +78,7 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   // Can be used to add custom timing information
   instance.decorateReply("setServerTiming", function (name, duration, description) {
     // Reference to the res object storing values …
-    const serverTiming = this.res[symbolServerTiming];
+    const serverTiming = this[symbolServerTiming];
     // … return if value already exists (all subsequent occurrences MUST be ignored without signaling an error) …
     if (serverTiming.hasOwnProperty(name)) {
       return false;
@@ -96,5 +90,4 @@ module.exports = fastifyPlugin((instance, opts, next) => {
   });
 
   next();
-  // Not before 0.31 (onSend hook added to this version)
-}, ">= 0.31");
+}, ">= 2.0");

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = fastifyPlugin((instance, opts, next) => {
     }
 
     // Calculate the duration, in nanoseconds …
-    const hrDuration = process.hrtime(request.req[symbolRequestTime]);
+    const hrDuration = process.hrtime(request[symbolRequestTime]);
     // … convert it to milliseconds …
     const duration = (hrDuration[0] * 1e3 + hrDuration[1] / 1e6).toFixed(opts.digits);
     // … add the header to the response

--- a/index.js
+++ b/index.js
@@ -89,5 +89,49 @@ module.exports = fastifyPlugin((instance, opts, next) => {
     return true;
   });
 
+  instance.decorateReply("asyncMeasureHr", async function (name, cb) {
+    const startHrTime = process.hrtime()
+
+    let result, error
+    try {
+      result = await cb()
+    } catch (err) {
+      error = err
+    }
+
+    const hrDuration = process.hrtime(startHrTime)
+    const duration = (hrDuration[0] * 1e3 + hrDuration[1] / 1e6).toFixed(2)
+
+    this.setServerTiming(name, duration)
+
+    if (error) {
+      throw error
+    }
+
+    return result
+  });
+
+  instance.decorateReply("syncMeasureHr", function (name, cb) {
+    const startHrTime = process.hrtime()
+
+    let result, error
+    try {
+      result = cb()
+    } catch (err) {
+      error = err
+    }
+
+    const hrDuration = process.hrtime(startHrTime)
+    const duration = (hrDuration[0] * 1e3 + hrDuration[1] / 1e6).toFixed(2)
+
+    this.setServerTiming(name, duration)
+
+    if (error) {
+      throw error
+    }
+
+    return result
+  });
+
   next();
 }, ">= 2.0");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-response-time",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Add X-Response-Time header at each request (in ms) for Fastify",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,7 @@
   "devDependencies": {
     "fastify": ">=2.0.0",
     "request": "^2.81.0",
+    "sleep-promise": "^8.0.1",
     "tap": "^12.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-response-time",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Add X-Response-Time header at each request (in ms) for Fastify",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "header"
   ],
   "devDependencies": {
-    "fastify": "^2.0.0-rc.2",
+    "fastify": ">=2.0.0",
     "request": "^2.81.0",
     "tap": "^12.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -8,6 +8,8 @@ const fastifyModule = require("fastify");
 const test = require("tap").test;
 const request = require("request");
 
+const sleep = require("sleep-promise");
+
 test("reply.send automatically add x-response-time header", (t) => {
   t.plan(8);
 
@@ -172,4 +174,89 @@ test("Check the Server-Timing header", (t) => {
       });
     });
   });
+
+  test("Check (a)syncMeasureHr", (t) => {
+    const fastify = fastifyModule();
+    fastify.register(fastifyRequestTime);
+    fastify.after((err) => {
+      t.error(err);
+    });
+
+    fastify.get("/wait-1-sec", async (request, reply) => {
+      try {
+        await reply.asyncMeasureHr("wait", async () => {
+          await sleep(1000)
+          if (request.query.error) {
+            throw new Error()
+          } else {
+            return "plop"
+          }
+        });
+      } catch (e) {}
+      reply.send("ok")
+    });
+
+    fastify.get("/no-wait", (request, reply) => {
+      try {
+        reply.syncMeasureHr("wait", () => {
+          if (request.query.error) {
+            throw new Error()
+          } else {
+            return "plop"
+          }
+        });
+      } catch (e) {}
+      reply.send("ok")
+    });
+
+    fastify.listen(0, (err) => {
+      t.error(err);
+
+      request({
+        method: "GET",
+        uri: `http://localhost:${fastify.server.address().port}/wait-1-sec`
+      }, (err, response, body) => {
+        t.error(err);
+        t.strictEqual(response.statusCode, 200);
+        t.ok(response.headers["server-timing"]);
+        const headers = response.headers["server-timing"];
+        t.ok(/wait;dur=100\d.\d+/.test(headers));
+
+        request({
+          method: "GET",
+          uri: `http://localhost:${fastify.server.address().port}/no-wait`
+        }, (err, response, body) => {
+          t.error(err);
+          t.strictEqual(response.statusCode, 200);
+          t.ok(response.headers["server-timing"]);
+          const headers = response.headers["server-timing"];
+          t.ok(/wait;dur=\d.\d+/.test(headers));
+
+          request({
+            method: "GET",
+            uri: `http://localhost:${fastify.server.address().port}/wait-1-sec?error=1`
+          }, (err, response, body) => {
+            t.error(err);
+            t.strictEqual(response.statusCode, 200);
+            t.ok(response.headers["server-timing"]);
+            const headers = response.headers["server-timing"];
+            t.ok(/wait;dur=\d.\d+/.test(headers));
+
+            request({
+              method: "GET",
+              uri: `http://localhost:${fastify.server.address().port}/no-wait?error=1`
+            }, (err, response, body) => {
+              t.error(err);
+              t.strictEqual(response.statusCode, 200);
+              t.ok(response.headers["server-timing"]);
+              const headers = response.headers["server-timing"];
+              t.ok(/wait;dur=\d.\d+/.test(headers));
+              t.end();
+              fastify.close();
+            });
+          });
+        });
+      });
+    })
+  })
 });


### PR DESCRIPTION
Fastify is currently at version 2.9
The line 87 was faulty for Fastify 2.0 (released), so, let's clean old code and checks for Fastify < 2.0